### PR TITLE
fix regexp to be more tolerant of line breaks

### DIFF
--- a/pr-metadata/pr-metadata.js
+++ b/pr-metadata/pr-metadata.js
@@ -22,7 +22,7 @@ const path          = require('path')
     , pkgData       = fs.existsSync(pkgFile) ? require(pkgFile) : {}
     , pkgId         = pkgToId(pkgData)
 
-    , collabRe      = '^\\* \\[([^\\]]+)\\]\\([^\\)]+\\) - \\*\\*([^\\*]+)\\*\\* &lt;([^&]+)&gt;$'
+    , collabRe      = '\\* \\[([^\\]]+)\\]\\([^\\)]+\\) -\\s\\*\\*([^\\*]+)\\*\\* &lt;([^&]+)&gt;'
       //e.g.: * [chrisdickinson](https://github.com/chrisdickinson) - **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt;
     , lgtmRe        = /(\W|^)lgtm(\W|$)/i
 


### PR DESCRIPTION
Fixes #5 

To make it more robust, it may be wise to replace all the space chars in the regexp string with `\s` (or, perhaps better yet, `\s+`) as well, but this PR is the minimum to fix it right now.

/cc @jasnell
